### PR TITLE
 add support for ep_set_title_on_pad 

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const eejs = require('ep_etherpad-lite/node/eejs');
 const padManager = require('ep_etherpad-lite/node/db/PadManager');
 const dateFormat = require('dateformat');
+const db = require('ep_etherpad-lite/node/db/DB').db;
 
 const PRIVATE_PAD_PREFIX = 'private_';
 
@@ -57,9 +58,17 @@ async function getDetailedPadList() {
     if (pad.head === 0) {
       continue;
     }
+    // support for ep_set_title_on_pad
+    let title;
+    db.get("title:"+padID, function(err, value){
+      if(!err && value) {
+        title = value;
+      }
+    });
     const time = await pad.getLastEdit();
     padData.push({
-      name: padID,
+      name: title ? title+' ('+padID+')' : padID,
+      padid: padID,
       lastRevision: pad.head,
       lastAccess: time
     });

--- a/templates/list.html
+++ b/templates/list.html
@@ -41,7 +41,7 @@
         <tbody>
         <% pads.forEach(function (pad) { %>
         <tr>
-            <td><a href="./p/<%= pad.name %>"><%= pad.name %></a></td>
+            <td><a href="/p/<%= pad.padid %>"><%= pad.name %></a></td>
             <td><%= pad.lastRevision %></td>
             <td><%= pad.lastAccess %></td>
         </tr>

--- a/templates/list.html
+++ b/templates/list.html
@@ -41,7 +41,7 @@
         <tbody>
         <% pads.forEach(function (pad) { %>
         <tr>
-            <td><a href="/p/<%= pad.padid %>"><%= pad.name %></a></td>
+            <td><a href="./p/<%= pad.padid %>"><%= pad.name %></a></td>
             <td><%= pad.lastRevision %></td>
             <td><%= pad.lastAccess %></td>
         </tr>


### PR DESCRIPTION
This adds support for ep_set_title_on_pad setups.

ep_set_title_on_pad provides pads with a title. With this changes ep_pad-lister will show the title in the list, if it is set.