### PR TITLE
Fix freeze on startup with Etherpad 1.8.8 and later

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ exports.eejsBlock_indexWrapper = function (hook_name, args, cb) {
   return cb();
 };
 
-exports.registerRoute = function (hook_name, args, cb) {
+exports.registerRoute = function (hook_name, args) {
   args.app.get('/pad-lister/static/bootstrap.min.css', (req, res) => {
     res.sendFile(__dirname + '/static/css/bootstrap.min.css');
   });


### PR DESCRIPTION
Etherpad expects the hook function to call the callback if the function takes a callback argument and will wait indefinitely for it to be called.

Fixes #9